### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "prettier": "^1.19.1",
     "semantic-release": "^15.13.19",
     "semantic-release-vsce": "^2.2.8",
-    "typescript": "^3.5.3",
+    "typescript": "^3.7.4",
     "vsce": "^1.42.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,10 +5948,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features