### PR TITLE
feat: implement a better way to resolve remote and upstream branch

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -8,9 +8,9 @@ import { getRemoteUrlReplacements } from './config'
  * Empty remote is returned if the upstream branch points to a local branch.
  * Empty upstream branch is returned if there is no upstream branch.
  */
-async function gitRemoteBranch(repoDir: string): Promise<[string, string]> {
+async function gitRemoteBranch(repoDirectory: string): Promise<[string, string]> {
     try {
-        const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD@{upstream}'], { cwd: repoDir })
+        const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD@{upstream}'], { cwd: repoDirectory })
         const remoteAndBranch = stdout.split('/')
         if (remoteAndBranch.length === 2) {
             const [remote, branch] = remoteAndBranch
@@ -21,7 +21,7 @@ async function gitRemoteBranch(repoDir: string): Promise<[string, string]> {
             return ['', remoteAndBranch[0]]
         }
         return ['', '']
-    } catch (error) {
+    } catch {
         return ['', '']
     }
 }
@@ -57,7 +57,7 @@ async function gitRemoteURL(repoDirectory: string, remoteName: string): Promise<
 async function gitDefaultRemoteURL(repoDirectory: string): Promise<string> {
     const [remote] = await gitRemoteBranch(repoDirectory)
     if (remote !== '') {
-        return await gitRemoteURL(repoDirectory, remote)
+        return gitRemoteURL(repoDirectory, remote)
     }
 
     // If we cannot find the remote name deterministically, we use the first

--- a/src/git.ts
+++ b/src/git.ts
@@ -5,26 +5,25 @@ import { getRemoteUrlReplacements } from './config'
 
 /**
  * Returns [remote, upstream branch].
- * Empty remote is returned if the upstream branch points to a local branch. 
+ * Empty remote is returned if the upstream branch points to a local branch.
  * Empty upstream branch is returned if there is no upstream branch.
  */
 async function gitRemoteBranch(repoDir: string): Promise<[string, string]> {
     try {
         const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD@{upstream}'], { cwd: repoDir })
         const remoteAndBranch = stdout.split('/')
-        if (remoteAndBranch.length == 2) {
+        if (remoteAndBranch.length === 2) {
             const [remote, branch] = remoteAndBranch
             return [remote, branch]
-        } else if (remoteAndBranch.length == 1) {
+        }
+        if (remoteAndBranch.length === 1) {
             // The upstream branch points to a local branch.
             return ['', remoteAndBranch[0]]
-        } else {
-            return ['', '']
         }
+        return ['', '']
     } catch (error) {
         return ['', '']
     }
-
 }
 
 /**
@@ -56,7 +55,7 @@ async function gitRemoteURL(repoDirectory: string, remoteName: string): Promise<
  * Returns the remote URL.
  */
 async function gitDefaultRemoteURL(repoDirectory: string): Promise<string> {
-    const [remote,] = await gitRemoteBranch(repoDirectory)
+    const [remote] = await gitRemoteBranch(repoDirectory)
     if (remote !== '') {
         return await gitRemoteURL(repoDirectory, remote)
     }
@@ -92,9 +91,8 @@ async function gitBranch(repoDirectory: string): Promise<string> {
     if (origin !== '') {
         // The remote branch exists.
         return branch
-    } else {
-        return "HEAD"
     }
+    return 'HEAD'
 }
 
 /**

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,30 @@ import { log } from './log'
 import { getRemoteUrlReplacements } from './config'
 
 /**
+ * Returns [remote, upstream branch].
+ * Empty remote is returned if the upstream branch points to a local branch. 
+ * Empty upstream branch is returned if there is no upstream branch.
+ */
+async function gitRemoteBranch(repoDir: string): Promise<[string, string]> {
+    try {
+        const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD@{upstream}'], { cwd: repoDir })
+        const remoteAndBranch = stdout.split('/')
+        if (remoteAndBranch.length == 2) {
+            const [remote, branch] = remoteAndBranch
+            return [remote, branch]
+        } else if (remoteAndBranch.length == 1) {
+            // The upstream branch points to a local branch.
+            return ['', remoteAndBranch[0]]
+        } else {
+            return ['', '']
+        }
+    } catch (error) {
+        return ['', '']
+    }
+
+}
+
+/**
  * Returns the names of all git remotes, e.g. ["origin", "foobar"]
  */
 async function gitRemotes(repoDirectory: string): Promise<string[]> {
@@ -29,9 +53,16 @@ async function gitRemoteURL(repoDirectory: string, remoteName: string): Promise<
 }
 
 /**
- * Returns the remote URL of the first Git remote found.
+ * Returns the remote URL.
  */
 async function gitDefaultRemoteURL(repoDirectory: string): Promise<string> {
+    const [remote,] = await gitRemoteBranch(repoDirectory)
+    if (remote !== '') {
+        return await gitRemoteURL(repoDirectory, remote)
+    }
+
+    // If we cannot find the remote name deterministically, we use the first
+    // Git remote found.
     const remotes = await gitRemotes(repoDirectory)
     if (remotes.length === 0) {
         throw new Error('no configured git remotes')
@@ -52,12 +83,18 @@ async function gitRootDirectory(repoDirectory: string): Promise<string> {
 }
 
 /**
- * Returns either the current branch name of the repository OR in all
- * other cases (e.g. detached HEAD state), it returns "HEAD".
+ * Returns either the current remote branch name of the repository OR in all
+ * other cases (e.g. detached HEAD state, upstream branch points to a local
+ * branch), it returns "HEAD".
  */
 async function gitBranch(repoDirectory: string): Promise<string> {
-    const { stdout } = await execa('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: repoDirectory })
-    return stdout
+    const [origin, branch] = await gitRemoteBranch(repoDirectory)
+    if (origin !== '') {
+        // The remote branch exists.
+        return branch
+    } else {
+        return "HEAD"
+    }
 }
 
 /**


### PR DESCRIPTION
### Problem
From #110 
> When multiple remotes are returned from git remote, this extension defaults to using the first returned remote name. This can be frustrating when the first remote name is not the desired remote to use.

And 
when the local branch name doesn't exist in the remote, the link generated by the current implementation leads to a 404 Not Found (See https://github.com/sourcegraph/sourcegraph-vscode/pull/24#issuecomment-634181548). 

### Changes
Use `git rev-parse --abbrev-ref HEAD@{upstream}` to resolve the remote name and upstream branch. Use the remote if it exists instead of the first remote in the list. It could potentially solve the issue mentioned in #110. This command could also resolve the upstream branch if it exists. If not, it will use `HEAD` instead. This should solve the second problem mentioned above.

### Tests
Mannually run `open file in sourcegraph` in the following scenarios:
local branch -> upstream branch -> sourcegraph
1. local: master -> upstream: origin/master -> sourcegraph: master
2. local: test ->  upstream: origin/test -> sourcegraph: test
3. local: test2 -> upstream: test1 (local branch) -> sourcegraph: master
4. local: test2 -> no upstream -> sourcegraph: master
5. local: detached HEAD -> N/A -> sourcegraph: master