### PR TITLE
Fix: Fallback to upstream branch name when remote does not match branch

### DIFF
--- a/src/git/remoteNameAndBranch.test.ts
+++ b/src/git/remoteNameAndBranch.test.ts
@@ -62,10 +62,20 @@ describe('git', () => {
             assert.strictEqual(branch, 'feature', 'incorrect branch name')
         })
 
-        it('falls back to first remote and branch when branch is not pushed to upstream', async () => {
+        it('falls back to first remote and upstream branch when branch does not match upstream', async () => {
             const { remoteName, branch } = await gitRemoteNameAndBranch(
                 '',
                 createMockGitHelpers(['origin'], 'feature', 'origin/master')
+            )
+
+            assert.strictEqual(remoteName, 'origin', 'incorrect remote name')
+            assert.strictEqual(branch, 'master', 'incorrect branch name')
+        })
+
+        it('falls back to first remote and branch when remote does not match upstream', async () => {
+            const { remoteName, branch } = await gitRemoteNameAndBranch(
+                '',
+                createMockGitHelpers(['origin'], 'feature', 'upstream/master')
             )
 
             assert.strictEqual(remoteName, 'origin', 'incorrect remote name')


### PR DESCRIPTION
Followup from testing https://github.com/sourcegraph/sourcegraph-vscode/pull/162. 

Normally when there's a mismatch between `upstreamAndBranch` and `branch` it's better to use the branch name in `upstreamAndBranch`. When using branch, it may be that branch is not existing in remote and therefore not accessible by SourceGraph (it returns 500 when that's the case). In that sense, it's better to fallback to the branch name included in `upstreamAndBranch` as that usually points to a branch that does exist upstream. 